### PR TITLE
Set QPS and Burst

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -20,6 +20,8 @@ type ExportOptions struct {
 	ExportDir string
 	Context   string
 	Namespace string
+	QPS       float32
+	Burst     int
 	genericclioptions.IOStreams
 }
 
@@ -70,6 +72,8 @@ func addFlagsForOptions(o *ExportOptions, cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.ExportDir, "export-dir", "export", "The path where files are to be exported")
 	cmd.Flags().StringVar(&o.Context, "context", "", "The kube context, if empty it will use the current context. If --namespace is set it will take precedence")
 	cmd.Flags().StringVar(&o.Namespace, "namespace", "", "The kube namespace to export.")
+	cmd.Flags().Float32VarP(&o.QPS, "qps", "q", 100, "Query Per Second Rate.")
+	cmd.Flags().IntVarP(&o.Burst, "burst", "b", 1000, "API Burst Rate.")
 }
 
 func (o *ExportOptions) run() error {
@@ -142,6 +146,9 @@ func (o *ExportOptions) run() error {
 	discoveryclient.Invalidate()
 
 	restConfig, err := o.configFlags.ToRESTConfig()
+	restConfig.Burst = o.Burst
+	restConfig.QPS = o.QPS
+
 	if err != nil {
 		fmt.Printf("cannot create rest config: %#v", err)
 	}


### PR DESCRIPTION
Without:
```
crane-export-playbook.yml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ****************************************************************************************************************************

TASK [Download crane] ***********************************************************************************************************************
changed: [localhost]

TASK [Remove export directories] ************************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Remove output directories] ************************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Remove transform directories] *********************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Run batched export] *******************************************************************************************************************
included: /home/jason/Documents/openshift/src/github.com/water-hole/crane-batch-migration/crane-export-batch.yml for localhost

TASK [export namespaces] ********************************************************************************************************************
changed: [localhost] => (item=robot-shop)

TASK [Check export status] ******************************************************************************************************************
FAILED - RETRYING: Check export status (30 retries left).
FAILED - RETRYING: Check export status (29 retries left).
FAILED - RETRYING: Check export status (28 retries left).
FAILED - RETRYING: Check export status (27 retries left).
FAILED - RETRYING: Check export status (26 retries left).
changed: [localhost] => (item={'started': 1, 'finished': 0, 'ansible_job_id': '688768572002.17470', 'results_file': '/home/jason/.ansible_async/688768572002.17470', 'changed': True, 'failed': False, 'async_item': 'robot-shop', 'ansible_loop_var': 'async_item'})

TASK [Create transforms] ********************************************************************************************************************
changed: [localhost]

TASK [Apply Transforms] *********************************************************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************************************************
localhost                  : ok=9    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


real	0m29.918s
user	0m4.470s
sys	0m1.036s
```

With:
```
time ansible-playbook crane-export-playbook.yml 
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ****************************************************************************************************************************

TASK [Download crane] ***********************************************************************************************************************
changed: [localhost]

TASK [Remove export directories] ************************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Remove output directories] ************************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Remove transform directories] *********************************************************************************************************
ok: [localhost] => (item=robot-shop)

TASK [Run batched export] *******************************************************************************************************************
included: /home/jason/Documents/openshift/src/github.com/water-hole/crane-batch-migration/crane-export-batch.yml for localhost

TASK [export namespaces] ********************************************************************************************************************
changed: [localhost] => (item=robot-shop)

TASK [Check export status] ******************************************************************************************************************
FAILED - RETRYING: Check export status (30 retries left).
changed: [localhost] => (item={'started': 1, 'finished': 0, 'ansible_job_id': '465733791748.19832', 'results_file': '/home/jason/.ansible_async/465733791748.19832', 'changed': True, 'failed': False, 'async_item': 'robot-shop', 'ansible_loop_var': 'async_item'})

TASK [Create transforms] ********************************************************************************************************************
changed: [localhost]

TASK [Apply Transforms] *********************************************************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************************************************
localhost                  : ok=9    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


real	0m7.514s
user	0m2.082s
sys	0m0.501s
```